### PR TITLE
Added smart feature for predicting next purchase Date

### DIFF
--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -72,7 +72,7 @@ export async function addItem(listId, { itemName, daysUntilNextPurchase }) {
 		totalPurchases: 0,
 	});
 
-	console.log('add Item:', dateCreated);
+	//console.log('add Item:', itemData.dateCreated);
 }
 
 /**
@@ -88,54 +88,83 @@ export async function updateItem(listId, id, itemData) {
 	 * this function must accept!
 	 */
 	// this variable gets the days since last transaction
-	let {
-		isChecked,
-		//name,
-		dateLastPurchased,
-		dateCreated,
-		dateNextPurchased,
-		totalPurchases,
-	} = itemData;
+	//let {
+	//	id,
+
+	//	isChecked,
+	//	//name,
+	//	dateLastPurchased,
+	//	itemData.dateCreated,
+	//	itemData.dateNextPurchased,
+	//	totalPurchases,
+	//} = itemData;
 
 	let daysSinceLastPurchase;
 	let previousEstimate;
 
 	console.log(itemData);
-	// if(isChecked){
-
-	if (dateLastPurchased) {
-		console.log('dateNextPurchased1', dateNextPurchased.toMillis());
-		console.log('dateLastPurchased1', dateLastPurchased.toMillis());
-		console.log('dateCreated1', dateCreated);
+	// if (isChecked) {
+	console.log('in isChecked condition', itemData.isChecked);
+	if (itemData.dateLastPurchased) {
+		console.log(
+			'itemData.dateNextPurchased1',
+			itemData.dateNextPurchased.toMillis(),
+		);
+		console.log('dateLastPurchased1', itemData.dateLastPurchased.toMillis());
+		console.log('itemData.dateCreated1', itemData.dateCreated);
 
 		previousEstimate = getDaysBetweenDates(
-			dateLastPurchased.toMillis(),
-			dateNextPurchased.toMillis(),
+			itemData.dateLastPurchased.toMillis(),
+			itemData.dateNextPurchased.toMillis(),
 		);
 
-		daysSinceLastPurchase = getDaysBetweenDates(dateLastPurchased.toMillis());
+		daysSinceLastPurchase = getDaysBetweenDates(
+			itemData.dateLastPurchased.toMillis(),
+		);
 	} else {
-		console.log('dateNextPurchased2', dateNextPurchased);
-		console.log('dateLastPurchased2', dateLastPurchased);
-		console.log('dateCreated2', dateCreated);
-		daysSinceLastPurchase = getDaysBetweenDates(dateCreated.toMillis());
+		console.log('itemData.dateNextPurchased2', itemData.dateNextPurchased);
+		console.log('dateLastPurchased2', itemData.dateLastPurchased);
+		console.log('itemData.dateCreated2', itemData.dateCreated);
+
+		previousEstimate = getDaysBetweenDates(
+			itemData.dateCreated.toMillis(),
+			itemData.dateNextPurchased.toMillis(),
+		);
+
+		daysSinceLastPurchase = getDaysBetweenDates(
+			itemData.dateCreated.toMillis(),
+		);
 	}
 
 	let updatePreviousEstimate = calculateEstimate(
 		previousEstimate,
 		daysSinceLastPurchase,
-		totalPurchases,
+		itemData.totalPurchases,
 	);
-
-	itemData = {
-		id,
-		//name,
-		isChecked,
-		dateCreated,
-		dateLastPurchased: new Date(),
-		dateNextPurchased: getFutureDate(updatePreviousEstimate),
-		totalPurchases,
-	};
+	itemData.dateLastPurchased = new Date();
+	itemData.dateNextPurchased = getFutureDate(updatePreviousEstimate);
+	itemData.totalPurchases = itemData.totalPurchases + 1;
+	//itemData = {
+	//	id,
+	//	//name,
+	//	isChecked,
+	//	itemData.dateCreated,
+	//	dateLastPurchased: new Date(),
+	//	itemData.dateNextPurchased: getFutureDate(updatePreviousEstimate),
+	//	totalPurchases: totalPurchases + 1,
+	//};
+	// }
+	//  else {
+	// 	itemData = {
+	// 		id: id,
+	// 		name: name,
+	// 		isChecked: isChecked,
+	// 		itemData.dateCreated: itemData.dateCreated,
+	// 		dateLastPurchased: dateLastPurchased,
+	// 		itemData.dateNextPurchased: itemData.dateNextPurchased,
+	// 		totalPurchases: totalPurchases,
+	// 	};
+	// }
 	console.log('inside update item:', updatePreviousEstimate);
 	const itemCollectionRef = doc(db, listId, id);
 	return await updateDoc(itemCollectionRef, itemData);

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -82,37 +82,10 @@ export async function addItem(listId, { itemName, daysUntilNextPurchase }) {
  * @param {Object} itemData fields in each document of the firebase collection
  */
 export async function updateItem(listId, id, itemData) {
-	/**
-	 * TODO: Fill this out so that it uses the correct Firestore function
-	 * to update an existing item! You'll need to figure out what arguments
-	 * this function must accept!
-	 */
-	// this variable gets the days since last transaction
-	//let {
-	//	id,
-
-	//	isChecked,
-	//	//name,
-	//	dateLastPurchased,
-	//	itemData.dateCreated,
-	//	itemData.dateNextPurchased,
-	//	totalPurchases,
-	//} = itemData;
-
 	let daysSinceLastPurchase;
 	let previousEstimate;
 
-	console.log(itemData);
-	// if (isChecked) {
-	console.log('in isChecked condition', itemData.isChecked);
 	if (itemData.dateLastPurchased) {
-		console.log(
-			'itemData.dateNextPurchased1',
-			itemData.dateNextPurchased.toMillis(),
-		);
-		console.log('dateLastPurchased1', itemData.dateLastPurchased.toMillis());
-		console.log('itemData.dateCreated1', itemData.dateCreated);
-
 		previousEstimate = getDaysBetweenDates(
 			itemData.dateLastPurchased.toMillis(),
 			itemData.dateNextPurchased.toMillis(),
@@ -122,10 +95,6 @@ export async function updateItem(listId, id, itemData) {
 			itemData.dateLastPurchased.toMillis(),
 		);
 	} else {
-		console.log('itemData.dateNextPurchased2', itemData.dateNextPurchased);
-		console.log('dateLastPurchased2', itemData.dateLastPurchased);
-		console.log('itemData.dateCreated2', itemData.dateCreated);
-
 		previousEstimate = getDaysBetweenDates(
 			itemData.dateCreated.toMillis(),
 			itemData.dateNextPurchased.toMillis(),
@@ -144,28 +113,7 @@ export async function updateItem(listId, id, itemData) {
 	itemData.dateLastPurchased = new Date();
 	itemData.dateNextPurchased = getFutureDate(updatePreviousEstimate);
 	itemData.totalPurchases = itemData.totalPurchases + 1;
-	//itemData = {
-	//	id,
-	//	//name,
-	//	isChecked,
-	//	itemData.dateCreated,
-	//	dateLastPurchased: new Date(),
-	//	itemData.dateNextPurchased: getFutureDate(updatePreviousEstimate),
-	//	totalPurchases: totalPurchases + 1,
-	//};
-	// }
-	//  else {
-	// 	itemData = {
-	// 		id: id,
-	// 		name: name,
-	// 		isChecked: isChecked,
-	// 		itemData.dateCreated: itemData.dateCreated,
-	// 		dateLastPurchased: dateLastPurchased,
-	// 		itemData.dateNextPurchased: itemData.dateNextPurchased,
-	// 		totalPurchases: totalPurchases,
-	// 	};
-	// }
-	console.log('inside update item:', updatePreviousEstimate);
+
 	const itemCollectionRef = doc(db, listId, id);
 	return await updateDoc(itemCollectionRef, itemData);
 }

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -71,8 +71,6 @@ export async function addItem(listId, { itemName, daysUntilNextPurchase }) {
 		name: itemName,
 		totalPurchases: 0,
 	});
-
-	//console.log('add Item:', itemData.dateCreated);
 }
 
 /**

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -71,6 +71,8 @@ export async function addItem(listId, { itemName, daysUntilNextPurchase }) {
 		name: itemName,
 		totalPurchases: 0,
 	});
+
+	console.log('add Item:', dateCreated);
 }
 
 /**
@@ -88,7 +90,7 @@ export async function updateItem(listId, id, itemData) {
 	// this variable gets the days since last transaction
 	let {
 		isChecked,
-		name,
+		//name,
 		dateLastPurchased,
 		dateCreated,
 		dateNextPurchased,
@@ -113,6 +115,9 @@ export async function updateItem(listId, id, itemData) {
 
 		daysSinceLastPurchase = getDaysBetweenDates(dateLastPurchased.toMillis());
 	} else {
+		console.log('dateNextPurchased2', dateNextPurchased);
+		console.log('dateLastPurchased2', dateLastPurchased);
+		console.log('dateCreated2', dateCreated);
 		daysSinceLastPurchase = getDaysBetweenDates(dateCreated.toMillis());
 	}
 
@@ -121,20 +126,17 @@ export async function updateItem(listId, id, itemData) {
 		daysSinceLastPurchase,
 		totalPurchases,
 	);
-	console.log('dateNextPurchased2', dateNextPurchased);
-	console.log('dateLastPurchased2', dateLastPurchased);
-	console.log('dateCreated2', dateCreated);
 
 	itemData = {
 		id,
-		name,
+		//name,
 		isChecked,
 		dateCreated,
 		dateLastPurchased: new Date(),
 		dateNextPurchased: getFutureDate(updatePreviousEstimate),
 		totalPurchases,
 	};
-	// }
+	console.log('inside update item:', updatePreviousEstimate);
 	const itemCollectionRef = doc(db, listId, id);
 	return await updateDoc(itemCollectionRef, itemData);
 }

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -8,7 +8,9 @@ import {
 	updateDoc,
 } from 'firebase/firestore';
 import { db } from './config';
-import { getFutureDate } from '../utils';
+import { getFutureDate, getDaysBetweenDates } from '../utils';
+
+// import { calculateEstimate } from '@the-collab-lab/shopping-list-utils ';
 
 /**
  * Subscribe to changes on a specific list in the Firestore database (listId), and run a callback (handleSuccess) every time a change happens.
@@ -71,7 +73,7 @@ export async function addItem(listId, { itemName, daysUntilNextPurchase }) {
 	});
 }
 
-export async function updateItem(listId, docId, items) {
+export async function updateItem(listId, docId, itemData) {
 	/**
 	 * TODO: Fill this out so that it uses the correct Firestore function
 	 * to update an existing item! You'll need to figure out what arguments
@@ -79,7 +81,7 @@ export async function updateItem(listId, docId, items) {
 	 */
 
 	const itemCollectionRef = doc(db, listId, docId);
-	return await updateDoc(itemCollectionRef, items);
+	return await updateDoc(itemCollectionRef, itemData);
 }
 
 export async function deleteItem() {

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -9,8 +9,7 @@ import {
 } from 'firebase/firestore';
 import { db } from './config';
 import { getFutureDate, getDaysBetweenDates } from '../utils';
-
-// import { calculateEstimate } from '@the-collab-lab/shopping-list-utils ';
+import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 
 /**
  * Subscribe to changes on a specific list in the Firestore database (listId), and run a callback (handleSuccess) every time a change happens.
@@ -70,6 +69,7 @@ export async function addItem(listId, { itemName, daysUntilNextPurchase }) {
 		isChecked: false,
 		name: itemName,
 		totalPurchases: 0,
+		previousEstimate: 0,
 	});
 }
 
@@ -79,6 +79,44 @@ export async function updateItem(listId, docId, itemData) {
 	 * to update an existing item! You'll need to figure out what arguments
 	 * this function must accept!
 	 */
+	let {
+		name,
+		dateCreated,
+		dateLastPurchased,
+		previousEstimate,
+		totalPurchases,
+		isChecked,
+		dateNextPurchased,
+	} = itemData;
+
+	let daysSinceLastPurchase;
+
+	if (dateLastPurchased) {
+		const itemLastPurchasedDate = dateLastPurchased.seconds;
+		console.log('purchased itemDataLast ', name, itemLastPurchasedDate);
+		daysSinceLastPurchase = getDaysBetweenDates(itemLastPurchasedDate);
+		console.log('purchaseDate diff', daysSinceLastPurchase);
+	} else {
+		const itemCreationDate = dateCreated.seconds;
+		console.log('created', name, itemCreationDate);
+		daysSinceLastPurchase = getDaysBetweenDates(itemCreationDate);
+		console.log('createdDate', daysSinceLastPurchase);
+	}
+	const secondsToDays = Math.floor(daysSinceLastPurchase / (3600 * 24));
+	let updatePreviousEstimate = calculateEstimate(
+		previousEstimate,
+		secondsToDays,
+		totalPurchases,
+	);
+	itemData = {
+		dateCreated,
+		dateLastPurchased,
+		dateNextPurchased,
+		isChecked,
+		name,
+		totalPurchases,
+		previousEstimate: updatePreviousEstimate,
+	};
 
 	const itemCollectionRef = doc(db, listId, docId);
 	return await updateDoc(itemCollectionRef, itemData);

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -8,8 +8,7 @@ import {
 	updateDoc,
 } from 'firebase/firestore';
 import { db } from './config';
-import { getFutureDate, getDaysBetweenDates } from '../utils';
-import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
+import { getFutureDate } from '../utils';
 
 /**
  * Subscribe to changes on a specific list in the Firestore database (listId), and run a callback (handleSuccess) every time a change happens.
@@ -79,44 +78,6 @@ export async function updateItem(listId, docId, itemData) {
 	 * to update an existing item! You'll need to figure out what arguments
 	 * this function must accept!
 	 */
-	let {
-		name,
-		dateCreated,
-		dateLastPurchased,
-		previousEstimate,
-		totalPurchases,
-		isChecked,
-		dateNextPurchased,
-	} = itemData;
-
-	let daysSinceLastPurchase;
-
-	if (dateLastPurchased) {
-		const itemLastPurchasedDate = dateLastPurchased.seconds;
-		console.log('purchased itemDataLast ', name, itemLastPurchasedDate);
-		daysSinceLastPurchase = getDaysBetweenDates(itemLastPurchasedDate);
-		console.log('purchaseDate diff', daysSinceLastPurchase);
-	} else {
-		const itemCreationDate = dateCreated.seconds;
-		console.log('created', name, itemCreationDate);
-		daysSinceLastPurchase = getDaysBetweenDates(itemCreationDate);
-		console.log('createdDate', daysSinceLastPurchase);
-	}
-	const secondsToDays = Math.floor(daysSinceLastPurchase / (3600 * 24));
-	let updatePreviousEstimate = calculateEstimate(
-		previousEstimate,
-		secondsToDays,
-		totalPurchases,
-	);
-	itemData = {
-		dateCreated,
-		dateLastPurchased,
-		dateNextPurchased,
-		isChecked,
-		name,
-		totalPurchases,
-		previousEstimate: updatePreviousEstimate,
-	};
 
 	const itemCollectionRef = doc(db, listId, docId);
 	return await updateDoc(itemCollectionRef, itemData);

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -98,9 +98,14 @@ export async function updateItem(listId, id, itemData) {
 	let daysSinceLastPurchase;
 	let previousEstimate;
 
+	console.log(itemData);
 	// if(isChecked){
 
 	if (dateLastPurchased) {
+		console.log('dateNextPurchased1', dateNextPurchased.toMillis());
+		console.log('dateLastPurchased1', dateLastPurchased.toMillis());
+		console.log('dateCreated1', dateCreated);
+
 		previousEstimate = getDaysBetweenDates(
 			dateLastPurchased.toMillis(),
 			dateNextPurchased.toMillis(),
@@ -116,15 +121,18 @@ export async function updateItem(listId, id, itemData) {
 		daysSinceLastPurchase,
 		totalPurchases,
 	);
+	console.log('dateNextPurchased2', dateNextPurchased);
+	console.log('dateLastPurchased2', dateLastPurchased);
+	console.log('dateCreated2', dateCreated);
 
 	itemData = {
-		// id,
-		// name,
-		// isChecked,
-		// dateCreated,
-		// dateLastPurchased,
+		id,
+		name,
+		isChecked,
+		dateCreated,
+		dateLastPurchased: new Date(),
 		dateNextPurchased: getFutureDate(updatePreviousEstimate),
-		// totalPurchases,
+		totalPurchases,
 	};
 	// }
 	const itemCollectionRef = doc(db, listId, id);

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,8 +1,8 @@
 import './ListItem.css';
 import { useState, useEffect } from 'react';
 import { updateItem } from '../api/firebase';
-import { getFutureDate, getDaysBetweenDates } from '../utils';
-import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
+// import { getFutureDate, getDaysBetweenDates } from '../utils';
+// import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 
 const milliSecondsInADay = 24 * 60 * 60 * 1000;
 const currentTimeInMilliseconds = Date.now();
@@ -28,22 +28,21 @@ export function ListItem({ listToken, item, name }) {
 
 	useEffect(() => {
 		if (timeElapsed >= milliSecondsInADay) {
-			const itemData = {
+			const newItemData = {
 				isChecked: false,
 			};
-			updateItem(listToken, id, itemData);
+			updateItem(listToken, id, newItemData);
 			setIsPurchased(false);
 		}
 	}, [listToken, timeElapsed, id]);
 
-	const handleCheckboxChange = (e) => {
+	const handleCheckboxChange = () => {
 		if (isPurchased) {
 			const itemData = {
-				name: name,
-				id: id,
 				isChecked: false,
 				dateCreated: dateCreated,
 				dateLastPurchased: dateLastPurchased,
+				dateNextPurchased: dateNextPurchased,
 				totalPurchases: totalPurchases,
 			};
 			setIsPurchased(false);
@@ -51,71 +50,15 @@ export function ListItem({ listToken, item, name }) {
 		} else {
 			const count = totalPurchases + 1;
 			const itemData = {
-				name: name,
-				id: id,
 				isChecked: true,
-				dateCreated: dateCreated,
+				dateCreated: dateCreated.seconds,
 				dateLastPurchased: new Date(),
 				totalPurchases: count,
 			};
-			updateItem(listToken, id, itemData);
 			setIsPurchased(true);
+			updateItem(listToken, id, itemData);
 		}
 	};
-
-	let daysSinceLastPurchase;
-	let previousEstimate;
-	let previousPurchase;
-
-	if (dateLastPurchased) {
-		previousPurchase = dateLastPurchased.seconds * 1000;
-
-		daysSinceLastPurchase = getDaysBetweenDates(previousPurchase, Date.now());
-		console.log(
-			'name=',
-			name,
-			'daysSinceLastPurchased',
-			Math.floor(daysSinceLastPurchase),
-		);
-
-		previousEstimate = getDaysBetweenDates(
-			previousPurchase,
-			dateNextPurchased.seconds * 1000,
-		);
-
-		console.log(
-			'name=',
-			name,
-			'purchaseDate diff',
-			Math.floor(previousEstimate),
-		);
-	} else {
-		previousPurchase = dateCreated.seconds * 1000;
-		// console.log('created', name, dateCreated);
-
-		daysSinceLastPurchase = getDaysBetweenDates(previousPurchase, Date.Now());
-
-		previousEstimate = getDaysBetweenDates(
-			previousPurchase,
-			dateNextPurchased.seconds * 1000,
-		);
-		// console.log('createdDate', daysSinceLastPurchase);
-	}
-	const secondsToDays = Math.floor(daysSinceLastPurchase / (3600 * 24));
-
-	let updatePreviousEstimate = calculateEstimate(
-		previousEstimate,
-		secondsToDays,
-		totalPurchases,
-	);
-
-	useEffect(() => {
-		const itemData = {
-			dateNextPurchased: getFutureDate(updatePreviousEstimate),
-		};
-		updateItem(listToken, id, itemData);
-	}, []);
-	// }, [listToken, id, dateNextPurchased]);
 
 	return (
 		<li className="ListItem" key={id}>

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -2,11 +2,13 @@ import './ListItem.css';
 import { useState, useEffect } from 'react';
 import { updateItem } from '../api/firebase';
 
+import { getDaysBetweenDates } from '../utils';
+
 const milliSecondsInADay = 24 * 60 * 60 * 1000;
 const currentTimeInMilliseconds = Date.now();
 
 export function ListItem({ listToken, item, name }) {
-	let { id, isChecked, dateLastPurchased, totalPurchases } = item;
+	let { id, isChecked, dateCreated, dateLastPurchased, totalPurchases } = item;
 
 	const [isPurchased, setIsPurchased] = useState(isChecked);
 
@@ -17,32 +19,58 @@ export function ListItem({ listToken, item, name }) {
 	const timeElasped =
 		currentTimeInMilliseconds - dateLastPurchasedInMilliseconds;
 
+	let days;
+	if (dateLastPurchased) {
+		const itemLastPurchasedDate = dateLastPurchased.seconds;
+		console.log('purchased itemDataLast ', name, itemLastPurchasedDate);
+		days = getDaysBetweenDates(itemLastPurchasedDate);
+		console.log('purchaseDate diff', days);
+	} else {
+		const itemCreationDate = dateCreated.seconds;
+		console.log('created', name, itemCreationDate);
+		days = getDaysBetweenDates(itemCreationDate);
+		console.log('createdDate', days);
+	}
+	const secondsToDays = Math.floor(days / (3600 * 24));
+
 	useEffect(() => {
 		if (timeElasped >= milliSecondsInADay) {
-			const items = {
+			const itemData = {
 				isChecked: false,
 			};
-			updateItem(listToken, id, items);
+			updateItem(listToken, id, itemData);
 			setIsPurchased(false);
 		}
 	}, [listToken, timeElasped, id]);
 
+	//const estimationTime = new calculateEstimate(previousEstimate, dateLastPurchased, totalPurchases){
+
+	//};
+
 	const handleCheckboxChange = (e) => {
 		if (isPurchased) {
-			const items = {
+			const itemData = {
+				name: name,
+				id: id,
 				isChecked: false,
+				dateCreated: dateCreated,
+				dateLastPurchased: dateLastPurchased,
+				totalPurchases: totalPurchases,
 			};
 			setIsPurchased(false);
-			updateItem(listToken, id, items);
+			updateItem(listToken, id, itemData);
 		} else {
 			const count = totalPurchases + 1;
-			const items = {
+			const itemData = {
+				name: name,
+				id: id,
 				isChecked: true,
+				dateCreated: dateCreated,
 				dateLastPurchased: new Date(),
 				totalPurchases: count,
 			};
 
-			updateItem(listToken, id, items);
+			updateItem(listToken, id, itemData);
 			setIsPurchased(true);
 		}
 	};

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -7,9 +7,10 @@ import { updateItem } from '../api/firebase';
 const milliSecondsInADay = 24 * 60 * 60 * 1000;
 const currentTimeInMilliseconds = Date.now();
 
-export function ListItem({ listToken, item, name }) {
+export function ListItem({ listToken, item }) {
 	let {
 		id,
+		name,
 		isChecked,
 		dateCreated,
 		dateLastPurchased,
@@ -27,36 +28,44 @@ export function ListItem({ listToken, item, name }) {
 		currentTimeInMilliseconds - dateLastPurchasedInMilliseconds;
 
 	useEffect(() => {
-		if (timeElapsed >= milliSecondsInADay) {
-			const newItemData = {
-				isChecked: false,
-				dateCreated: dateCreated,
-			};
+		if (isChecked && timeElapsed >= milliSecondsInADay) {
+			let newItemData = item;
+			newItemData.isChecked = false;
+			//const newItemData = {
+			//	id,
+			//	isChecked: false,
+			//	dateCreated: dateCreated,s
+			//	dateLastPurchased: dateLastPurchased,
+			//	dateNextPurchased: dateNextPurchased,
+			//	totalPurchases: totalPurchases,
+			//};
 			updateItem(listToken, id, newItemData);
 			setIsPurchased(false);
 		}
 	}, [listToken, timeElapsed, id]);
 
 	const handleCheckboxChange = () => {
+		let itemData = item;
 		if (isPurchased) {
-			const itemData = {
-				isChecked: false,
-				dateCreated: dateCreated,
-				dateLastPurchased: dateLastPurchased,
-				dateNextPurchased: dateNextPurchased,
-				totalPurchases: totalPurchases,
-			};
+			itemData.isChecked = false;
+			//const itemData = {
+			//	isChecked: false,
+			//	dateCreated: dateCreated,
+			//	dateLastPurchased: dateLastPurchased,
+			//	dateNextPurchased: dateNextPurchased,
+			//	totalPurchases: totalPurchases,
+			//};
 			setIsPurchased(false);
 			updateItem(listToken, id, itemData);
 		} else {
-			const count = totalPurchases + 1;
-			const itemData = {
-				isChecked: true,
-				dateCreated: dateCreated,
-				dateLastPurchased: dateLastPurchased,
-				dateNextPurchased: dateNextPurchased,
-				totalPurchases: count,
-			};
+			itemData.isChecked = true;
+			//const itemData = {
+			//	isChecked: true,
+			//	dateCreated: dateCreated,
+			//	dateLastPurchased: dateLastPurchased,
+			//	dateNextPurchased: dateNextPurchased,
+			//	totalPurchases: totalPurchases,
+			//};
 			console.log('total purchases inside handlebox change:', totalPurchases);
 			setIsPurchased(true);
 			updateItem(listToken, id, itemData);

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -30,6 +30,7 @@ export function ListItem({ listToken, item, name }) {
 		if (timeElapsed >= milliSecondsInADay) {
 			const newItemData = {
 				isChecked: false,
+				dateCreated: dateCreated,
 			};
 			updateItem(listToken, id, newItemData);
 			setIsPurchased(false);
@@ -51,11 +52,12 @@ export function ListItem({ listToken, item, name }) {
 			const count = totalPurchases + 1;
 			const itemData = {
 				isChecked: true,
-				dateCreated: dateCreated.seconds,
+				dateCreated: dateCreated,
 				dateLastPurchased: dateLastPurchased,
 				dateNextPurchased: dateNextPurchased,
 				totalPurchases: count,
 			};
+			console.log('total purchases inside handlebox change:', totalPurchases);
 			setIsPurchased(true);
 			updateItem(listToken, id, itemData);
 		}

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -52,7 +52,8 @@ export function ListItem({ listToken, item, name }) {
 			const itemData = {
 				isChecked: true,
 				dateCreated: dateCreated.seconds,
-				dateLastPurchased: new Date(),
+				dateLastPurchased: dateLastPurchased,
+				dateNextPurchased: dateNextPurchased,
 				totalPurchases: count,
 			};
 			setIsPurchased(true);

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -2,13 +2,18 @@ import './ListItem.css';
 import { useState, useEffect } from 'react';
 import { updateItem } from '../api/firebase';
 
-import { getDaysBetweenDates } from '../utils';
-
 const milliSecondsInADay = 24 * 60 * 60 * 1000;
 const currentTimeInMilliseconds = Date.now();
 
 export function ListItem({ listToken, item, name }) {
-	let { id, isChecked, dateCreated, dateLastPurchased, totalPurchases } = item;
+	let {
+		id,
+		isChecked,
+		dateCreated,
+		dateLastPurchased,
+		previousEstimate,
+		totalPurchases,
+	} = item;
 
 	const [isPurchased, setIsPurchased] = useState(isChecked);
 
@@ -19,20 +24,6 @@ export function ListItem({ listToken, item, name }) {
 	const timeElasped =
 		currentTimeInMilliseconds - dateLastPurchasedInMilliseconds;
 
-	let days;
-	if (dateLastPurchased) {
-		const itemLastPurchasedDate = dateLastPurchased.seconds;
-		console.log('purchased itemDataLast ', name, itemLastPurchasedDate);
-		days = getDaysBetweenDates(itemLastPurchasedDate);
-		console.log('purchaseDate diff', days);
-	} else {
-		const itemCreationDate = dateCreated.seconds;
-		console.log('created', name, itemCreationDate);
-		days = getDaysBetweenDates(itemCreationDate);
-		console.log('createdDate', days);
-	}
-	const secondsToDays = Math.floor(days / (3600 * 24));
-
 	useEffect(() => {
 		if (timeElasped >= milliSecondsInADay) {
 			const itemData = {
@@ -42,10 +33,6 @@ export function ListItem({ listToken, item, name }) {
 			setIsPurchased(false);
 		}
 	}, [listToken, timeElasped, id]);
-
-	//const estimationTime = new calculateEstimate(previousEstimate, dateLastPurchased, totalPurchases){
-
-	//};
 
 	const handleCheckboxChange = (e) => {
 		if (isPurchased) {
@@ -69,11 +56,17 @@ export function ListItem({ listToken, item, name }) {
 				dateLastPurchased: new Date(),
 				totalPurchases: count,
 			};
-
 			updateItem(listToken, id, itemData);
 			setIsPurchased(true);
 		}
 	};
+
+	useEffect(() => {
+		const itemData = {
+			previousEstimate: previousEstimate,
+		};
+		updateItem(listToken, id, itemData);
+	}, [listToken, id, previousEstimate]);
 
 	return (
 		<li className="ListItem" key={id}>

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -23,18 +23,18 @@ export function ListItem({ listToken, item, name }) {
 		? dateLastPurchased.seconds * 1000
 		: null;
 
-	const timeElasped =
+	const timeElapsed =
 		currentTimeInMilliseconds - dateLastPurchasedInMilliseconds;
 
 	useEffect(() => {
-		if (timeElasped >= milliSecondsInADay) {
+		if (timeElapsed >= milliSecondsInADay) {
 			const itemData = {
 				isChecked: false,
 			};
 			updateItem(listToken, id, itemData);
 			setIsPurchased(false);
 		}
-	}, [listToken, timeElasped, id]);
+	}, [listToken, timeElapsed, id]);
 
 	const handleCheckboxChange = (e) => {
 		if (isPurchased) {
@@ -68,26 +68,38 @@ export function ListItem({ listToken, item, name }) {
 	let previousPurchase;
 
 	if (dateLastPurchased) {
-		console.log('purchased itemDataLast ', name, dateLastPurchased);
-		previousPurchase = dateLastPurchased.seconds;
+		previousPurchase = dateLastPurchased.seconds * 1000;
 
 		daysSinceLastPurchase = getDaysBetweenDates(previousPurchase, Date.now());
-		//previousPurchase = dateLastPurchased
-		//date = date.Now()
+		console.log(
+			'name=',
+			name,
+			'daysSinceLastPurchased',
+			Math.floor(daysSinceLastPurchase),
+		);
 
-		previousEstimate = getDaysBetweenDates(previousPurchase, dateNextPurchased);
-		//previousPurchase = dateLastPurchased
-		//date = dateNextPurchased
+		previousEstimate = getDaysBetweenDates(
+			previousPurchase,
+			dateNextPurchased.seconds * 1000,
+		);
 
-		console.log('purchaseDate diff', daysSinceLastPurchase);
+		console.log(
+			'name=',
+			name,
+			'purchaseDate diff',
+			Math.floor(previousEstimate),
+		);
 	} else {
-		previousPurchase = dateCreated.seconds;
-		console.log('created', name, dateCreated);
+		previousPurchase = dateCreated.seconds * 1000;
+		// console.log('created', name, dateCreated);
 
 		daysSinceLastPurchase = getDaysBetweenDates(previousPurchase, Date.Now());
 
-		previousEstimate = getDaysBetweenDates(previousPurchase, dateNextPurchased);
-		console.log('createdDate', daysSinceLastPurchase);
+		previousEstimate = getDaysBetweenDates(
+			previousPurchase,
+			dateNextPurchased.seconds * 1000,
+		);
+		// console.log('createdDate', daysSinceLastPurchase);
 	}
 	const secondsToDays = Math.floor(daysSinceLastPurchase / (3600 * 24));
 
@@ -97,14 +109,13 @@ export function ListItem({ listToken, item, name }) {
 		totalPurchases,
 	);
 
-	// let smartPurchaseDate = getFutureDate(updatePreviousEstimate);
-
 	useEffect(() => {
 		const itemData = {
 			dateNextPurchased: getFutureDate(updatePreviousEstimate),
 		};
 		updateItem(listToken, id, itemData);
-	}, [listToken, id, dateNextPurchased]);
+	}, []);
+	// }, [listToken, id, dateNextPurchased]);
 
 	return (
 		<li className="ListItem" key={id}>

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,8 +1,6 @@
 import './ListItem.css';
 import { useState, useEffect } from 'react';
 import { updateItem } from '../api/firebase';
-// import { getFutureDate, getDaysBetweenDates } from '../utils';
-// import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 
 const milliSecondsInADay = 24 * 60 * 60 * 1000;
 const currentTimeInMilliseconds = Date.now();
@@ -31,14 +29,7 @@ export function ListItem({ listToken, item }) {
 		if (isChecked && timeElapsed >= milliSecondsInADay) {
 			let newItemData = item;
 			newItemData.isChecked = false;
-			//const newItemData = {
-			//	id,
-			//	isChecked: false,
-			//	dateCreated: dateCreated,s
-			//	dateLastPurchased: dateLastPurchased,
-			//	dateNextPurchased: dateNextPurchased,
-			//	totalPurchases: totalPurchases,
-			//};
+
 			updateItem(listToken, id, newItemData);
 			setIsPurchased(false);
 		}
@@ -48,25 +39,12 @@ export function ListItem({ listToken, item }) {
 		let itemData = item;
 		if (isPurchased) {
 			itemData.isChecked = false;
-			//const itemData = {
-			//	isChecked: false,
-			//	dateCreated: dateCreated,
-			//	dateLastPurchased: dateLastPurchased,
-			//	dateNextPurchased: dateNextPurchased,
-			//	totalPurchases: totalPurchases,
-			//};
+
 			setIsPurchased(false);
 			updateItem(listToken, id, itemData);
 		} else {
 			itemData.isChecked = true;
-			//const itemData = {
-			//	isChecked: true,
-			//	dateCreated: dateCreated,
-			//	dateLastPurchased: dateLastPurchased,
-			//	dateNextPurchased: dateNextPurchased,
-			//	totalPurchases: totalPurchases,
-			//};
-			console.log('total purchases inside handlebox change:', totalPurchases);
+
 			setIsPurchased(true);
 			updateItem(listToken, id, itemData);
 		}

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -10,3 +10,13 @@ const ONE_DAY_IN_MILLISECONDS = 86400000;
 export function getFutureDate(offset) {
 	return new Date(Date.now() + offset * ONE_DAY_IN_MILLISECONDS);
 }
+
+export function getDaysBetweenDates(previousPurchase) {
+	// 	//console.log('in dates=',previousPurchase, Date.now());
+	console.log(
+		'dates functions=',
+		Math.floor(Date.now() / 1000),
+		previousPurchase,
+	);
+	return Math.abs((Date.now() - previousPurchase) / ONE_DAY_IN_MILLISECONDS);
+}

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -12,11 +12,5 @@ export function getFutureDate(offset) {
 }
 
 export function getDaysBetweenDates(previousPurchase, date) {
-	// 	//console.log('in dates=',previousPurchase, Date.now());
-	console.log(
-		'dates functions=',
-		Math.floor(Date.now() / 1000),
-		previousPurchase,
-	);
 	return Math.abs((date - previousPurchase) / ONE_DAY_IN_MILLISECONDS);
 }

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -11,12 +11,12 @@ export function getFutureDate(offset) {
 	return new Date(Date.now() + offset * ONE_DAY_IN_MILLISECONDS);
 }
 
-export function getDaysBetweenDates(previousPurchase) {
+export function getDaysBetweenDates(previousPurchase, date) {
 	// 	//console.log('in dates=',previousPurchase, Date.now());
 	console.log(
 		'dates functions=',
 		Math.floor(Date.now() / 1000),
 		previousPurchase,
 	);
-	return Math.abs((Date.now() - previousPurchase) / ONE_DAY_IN_MILLISECONDS);
+	return Math.abs((date - previousPurchase) / ONE_DAY_IN_MILLISECONDS);
 }

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -11,6 +11,9 @@ export function getFutureDate(offset) {
 	return new Date(Date.now() + offset * ONE_DAY_IN_MILLISECONDS);
 }
 
-export function getDaysBetweenDates(previousPurchase, date) {
-	return Math.abs((date - previousPurchase) / ONE_DAY_IN_MILLISECONDS);
+export function getDaysBetweenDates(previousPurchase, currentDate) {
+	if (!currentDate) {
+		currentDate = Date.now();
+	}
+	return Math.abs((currentDate - previousPurchase) / ONE_DAY_IN_MILLISECONDS);
 }


### PR DESCRIPTION


## Description

<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? Reminder: This will be a publicly facing representation of your work (READ: help you land that sweet dev gig). -->
This code ensures that the suggested date for the next purchase of an item is updated to reflect how often the user actually buys the item. When an item is first added, the user makes a choice of frequency (7, 14, or 21 days) but may end up purchasing at a different interval. To be able to do this, we leveraged the function calculateEstimate from @the-collab-lab/shopping-list-utils which takes in the number of purchases (less than 2 and it is a default value of the original choice the user made), the previous estimated interval, and the number of days since the last purchase. For the previous estimate, if the item had been purchased before, we calculated the difference between the last purchased date and the next purchased date. If it had never been purchased before, we used the date created and the next purchase date. For the days since last purchase, if there was a previous purchase, we used the difference between the last purchase and current purchase date. If there was not a previous purchase, we used the difference between the date created and the current purchase date.

## Related Issue
closes #10
<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->

## Acceptance Criteria

- A getDaysBetweenDates function is exported from utils/dates.js and imported into api/firebase.js
-  This function takes two JavaScript Dates and return the number of days that have passed between them
-  When the user purchases an item, the item’s dateNextPurchased property is calculated using the calculateEstimate function and saved to the Firestore database
- -  dateNextPurchased is saved as a date, not a number


<!-- Include AC from the Github issue -->

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓ | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before
DateNextPurchased always use user input value

### After
DateNextPurchased now reflects actual frequency of purchases

## Testing Steps / QA Criteria
Add new Item to the list In firestore : totalPurchase to be greater than 2, dateCreated to be date in the past. Set a dateLastPurchased ,check the item on the list to watch the dateNextPurchased changed.
to check for items with less than 2 purchases: Add new Item to the list , check item , in firestore dateNextPurchased should reflect choice when item added(ex: soon=7 days in the future, kind of soon= 14 days in the future ,notsoon=30 days in the future.
